### PR TITLE
Fix deprecating set-output commands

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -152,8 +152,8 @@ wait_for_workflow_to_finish() {
   echo "Waiting for workflow to finish:"
   echo "The workflow id is [${last_workflow_id}]."
   echo "The workflow logs can be found at ${last_workflow_url}"
-  echo "::set-output name=workflow_id::${last_workflow_id}"
-  echo "::set-output name=workflow_url::${last_workflow_url}"
+  echo "workflow_id=${last_workflow_id}" >> $GITHUB_OUTPUT
+  echo "workflow_url=${last_workflow_url}" >> $GITHUB_OUTPUT
   echo ""
 
   conclusion=null


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

TL;DR

> - name: Save state
>   run: echo "::save-state name={name}::{value}"
> 
> - name: Set output
>   run: echo "::set-output name={name}::{value}"

> - name: Save state
>   run: echo "{name}={value}" >> $GITHUB_STATE
> 
> - name: Set output
>   run: echo "{name}={value}" >> $GITHUB_OUTPUT


Ref: https://github.com/netdata/infra/issues/3541